### PR TITLE
Site-Änderungen FFMZ

### DIFF
--- a/modules
+++ b/modules
@@ -1,0 +1,5 @@
+GLUON_SITE_FEEDS='ffmwu'
+
+PACKAGES_FFMWU_REPO=git://github.com/freifunk-mwu/packages-ffmwu.git
+PACKAGES_FFMWU_BRANCH=master
+PACKAGES_FFMWU_COMMIT=45449b33abcc0ff181cfc38c32cbe43fbc94c2ce

--- a/site.conf
+++ b/site.conf
@@ -69,8 +69,14 @@
   mesh = {
     -- Options specific to the batman-adv routing protocol (optional)
     batman_adv = {
-      gw_sel_class = 1,
+      gw_sel_class = 15,
     },
+  },
+
+  -- Filter all router advertisements not originating from Gateway with best link quality (TQ)
+  radv_filterd = {
+    -- threshold should be in sync with mesh.batman_adv.gw_sel_class
+    threshold = 15,
   },
 
   fastd_mesh_vpn = {
@@ -95,6 +101,22 @@
 		    lotuswurzel = {
 			key = 'd73479cc97a87ffd4b256a873e505f3264408ed077b248358c52e8dc82bbfc07',
 			remotes = {'"lotuswurzel.freifunk-mwu.de" port 10037'},
+		    },
+		    sparegate1 = {
+			key = 'eafd83b5df271981b8c6219a3103b3b094ad67cacc138492f800af26779dac57',
+			remotes = {'"sparegate1.freifunk-mwu.de" port 10037'},
+		    },
+		    sparegate2 = {
+			key = '7af8602493e5bf01e9022ed8c9ac4ad7cc01f180d139a0cc9057bc67bb6e871a',
+			remotes = {'"sparegate2.freifunk-mwu.de" port 10037'},
+		    },
+		    sparegate3 = {
+			key = 'dac4ffc29c347f1bc8c4bcae604c531e80962e3552395478f3a77723277fe807',
+			remotes = {'"sparegate3.freifunk-mwu.de" port 10037'},
+		    },
+		    sparegate4 = {
+			key = 'b085b0a7375c266bef9a7bbc51817ed9b625c67a79908ffbaa6ce9a7936d458d',
+			remotes = {'"sparegate4.freifunk-mwu.de" port 10037'},
 		    },
 		},
         },

--- a/site.mk
+++ b/site.mk
@@ -22,6 +22,7 @@ GLUON_SITE_PACKAGES := \
 	gluon-luci-wifi-config \
 	gluon-next-node \
 	gluon-mesh-vpn-fastd \
+	gluon-radv-filterd \
 	gluon-radvd \
 	gluon-respondd \
 	gluon-setup-mode \


### PR DESCRIPTION
Dieser PR fügt drei wichtige Änderungen aus der Site des Freifunk Mainz hinzu.

1. `gw_sel_class` auf 15 gesetzt (https://github.com/freifunk-mwu/site-ffmwu/commit/7886ee08c84caabd07216185a933a5c01a3492eb)
2. 4 neue Gateways für zukünftige Nutzung hinzugefügt (1-2 in naher Zukunft)
3. Paket `gluon-radv-filterd` hinzugefügt

Punkt 3. ist hierbei der wichtigste da wir durch die Aktivierung von öffentlichem IPv6 für alle Clients den Seiteneffekt haben, dass sehr viel Traffic zwischen den Gateways hin und her fließt. Dies wird durch `gluon-radv-filterd` verhindert. Der Dienst filtert alle Router Advertisements die nicht vom Gateway mit der besten TQ kommen. Zusammen mit neuen Subnetzen die wir auf den Gateways in den kommenden Tagen einrichten werden, wird dies unseren internen Traffic stark reduzieren. Wir bitten euch das Paket auch schnellstmöglich in eure Firmware zu integrieren.

Julian
Freifunk MWU Firmware-Team